### PR TITLE
Update redshift-sqlalchemy --> sqlalchemy-redshift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,15 +56,12 @@ install:
 
   # Install various deps
   - conda uninstall toolz
-  - pip install -U toolz sas7bdat psycopg2 dill 'pymongo<3'
+  - pip install -U toolz sas7bdat psycopg2 dill 'pymongo<3' sqlalchemy-redshift
   - pip install git+git://github.com/blaze/dask.git#egg=dask-dev[complete]
   - if [ -n "$PANDAS_VERSION" ]; then pip install $PANDAS_VERSION; fi
 
   # install pyspark
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' || $TRAVIS_PYTHON_VERSION == '3.4' ]]; then conda install spark=$SPARK_VERSION -c blaze -c https://conda.binstar.org/blaze/channel/dev -c anaconda-cluster; fi
-
-  # redshift sqlalchemy dialect
-  - pip install --upgrade git+git://github.com/graingert/redshift_sqlalchemy
 
 # Before_script section stolen from fabric
 # See license https://github.com/fabric/fabric/blob/master/LICENSE

--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -7,7 +7,7 @@ Dependencies
 * `boto <http://boto.readthedocs.org>`_
 * `sqlalchemy <http://docs.sqlalchemy.org/en/rel_0_9>`_
 * `psycopg2 <http://initd.org/psycopg>`_
-* `redshift_sqlalchemy <https://github.com/cpcloud/redshift_sqlalchemy>`_
+* `sqlalchemy_redshift <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift>`_
 
 Setup
 -----
@@ -28,7 +28,7 @@ Interface
 ``odo`` provides access to the following AWS services:
 
 * `S3 <http://aws.amazon.com/s3>`_ via boto.
-* `Redshift <http://aws.amazon.com/redshift>`_ via a `SQLAlchemy dialect <https://github.com/cpcloud/redshift_sqlalchemy>`_
+* `Redshift <http://aws.amazon.com/redshift>`_ via a `SQLAlchemy dialect <https://github.com/sqlalchemy-redshift/sqlalchemy-redshift>`_
 
 URIs
 ----

--- a/docs/source/whatsnew/0.5.1.txt
+++ b/docs/source/whatsnew/0.5.1.txt
@@ -26,6 +26,8 @@ None
 Improved Backends
 -----------------
 
+* Sqlalchemy-redshift upgraded to 5.0 and installed from PyPI (:issue: `478`).
+
 None
 
 API Changes

--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -182,7 +182,7 @@ def compile_from_csv_postgres(element, compiler, **kwargs):
 try:
     import boto
     from odo.backends.aws import S3
-    from redshift_sqlalchemy.dialect import CopyCommand
+    from sqlalchemy_redshift.dialect import CopyCommand
 except ImportError:
     pass
 else:

--- a/odo/backends/tests/test_s3_redshift.py
+++ b/odo/backends/tests/test_s3_redshift.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.skipif(sys.platform == 'win32',
 sa = pytest.importorskip('sqlalchemy')
 boto = pytest.importorskip('boto')
 pytest.importorskip('psycopg2')
-pytest.importorskip('redshift_sqlalchemy')
+pytest.importorskip('sqlalchemy_redshift')
 
 from contextlib import closing
 import json


### PR DESCRIPTION
The redshift-sqlalchemy module has been renamed to sqlalchemy-redshift. A couple things were changed:

- installing via pip from PyPI, instead of pip+git
- [Importing it via `import redshift-sqlalchemy` is deprecated](https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/blob/a1f699495cbf41a6c8fea03c604da7b3bce811b2/redshift_sqlalchemy/__init__.py#L12-L17), so the import was changed.
- added whatsnew entry for 0.5.1 release